### PR TITLE
db host fix

### DIFF
--- a/invidious/Chart.yaml
+++ b/invidious/Chart.yaml
@@ -4,7 +4,7 @@ description: Invidious is an alternative front-end to YouTube
 
 type: application
 
-version: 2.0.4
+version: 2.0.5
 appVersion: v2.20240427
 
 dependencies:
@@ -20,7 +20,7 @@ keywords:
   - proxy
   - video
   - privacy
-  
+
 home: https://invidious.io
 icon: https://raw.githubusercontent.com/iv-org/invidious/05988c1c49851b7d0094fca16aeaf6382a7f64ab/assets/favicon-32x32.png
 

--- a/invidious/templates/_helpers.tpl
+++ b/invidious/templates/_helpers.tpl
@@ -50,3 +50,20 @@ Selector labels
 app.kubernetes.io/name: {{ include "invidious.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Initialize default values and validate database configuration
+*/}}
+{{- define "invidious.init-defaults" -}}
+{{/* Set default PostgreSQL host if using in-chart PostgreSQL */}}
+{{- if .Values.postgresql.enabled }}
+    {{- if not .Values.config.db.host }}
+    {{- $_ := set .Values.config.db "host" (printf "%s-postgresql" .Release.Name) }}
+    {{- end }}
+{{- else }}
+{{/* Fail if external database host is not provided when in-chart PostgreSQL is disabled */}}
+    {{- if not .Values.config.db.host }}
+    {{- fail "config.db.host must be set when postgresql.enabled is false" }}
+    {{- end }}
+{{- end }}
+{{- end -}}

--- a/invidious/templates/deployment.yaml
+++ b/invidious/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "invidious.init-defaults" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/invidious/templates/secret.yaml
+++ b/invidious/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- include "invidious.init-defaults" . }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/invidious/values.yaml
+++ b/invidious/values.yaml
@@ -88,7 +88,7 @@ config:
   db:
     user: kemal
     password: kemal
-    host: invidious-postgresql
+    host: ""
     port: 5432
     dbname: invidious
   port: 3000


### PR DESCRIPTION
The default config for db.host is "invidious-postgresql" which only
works when the chart is installed with a release name of "invidious".

Changed the default db.host value to "${release_name}-postgresql". (could fix #3)

Also changed pullPolicy to IfNotPresent.